### PR TITLE
adjusting front end to support exporting ffmpeg-remix

### DIFF
--- a/functions/convert-to-video/index.js
+++ b/functions/convert-to-video/index.js
@@ -49,12 +49,14 @@ const convertToVideo = function({ src, outputFullPathName }) {
   return new Promise((resolve, reject) => {
     ffmpeg(src)
       .output(outputFullPathName)
-      .withVideoCodec('libx264')
+      // .withVideoCodec('libx264')
+      .videoCodec('libx264')
+      .audioCodec('aac')
       // for details on the ffmpeg flags see https://trac.ffmpeg.org/wiki/Encode/H.264
       // removing '-vf scale=-1:360' to make it compatible with vertical videos. In vertical video it would work as '-vf scale=360:-1'
       .addOptions(['-preset ultrafast', '-f mp4', '-crf 28', '-tune zerolatency', '-movflags +faststart'])
       // .withVideoBitrate(1024)
-      .withAudioCodec('aac')
+      // .withAudioCodec('aac')
       .on('end', () => {
         resolve(outputFullPathName);
       })

--- a/functions/index.js
+++ b/functions/index.js
@@ -195,7 +195,7 @@ exports.onDeleteProjectCleanUp = functions
 
 // https://firebase.google.com/docs/functions/callable#web
 // https://github.com/pietrop/digital-paper-edit-electron/blob/master/src/ElectronWrapper/ffmpeg-remix/index.js
-exports.ffmpegRemixVideo = functions.runWith(MAX_RUNTIME_OPTS).https.onCall(async (data, context) => {
+exports.ffmpegRemix = functions.runWith(MAX_RUNTIME_OPTS).https.onCall(async (data, context) => {
   console.log('data', JSON.stringify(data));
   const bucket = admin.storage().bucket();
   const fileName = data.output;
@@ -204,9 +204,9 @@ exports.ffmpegRemixVideo = functions.runWith(MAX_RUNTIME_OPTS).https.onCall(asyn
   const localFileNamePath = path.join(os.tmpdir(), data.output);
   data.output = localFileNamePath;
   console.log('data.output', data.output);
-
+  const { waveForm, waveFormMode, waveFormColor } = data;
   return new Promise((resolve, reject) =>
-    remix(data, null, null, null, async (err, result) => {
+    remix(data, waveForm, waveFormMode, waveFormColor, async (err, result) => {
       if (err) {
         console.log('err', err);
         reject(err);
@@ -227,23 +227,11 @@ exports.ffmpegRemixVideo = functions.runWith(MAX_RUNTIME_OPTS).https.onCall(asyn
         // without resumable false, this seems to fail
         resumable: false,
       });
-      // clean up video preview mp4 file on the cloud function
-      // const storage = admin.storage().bucket();
-      // const pathReferenceRemix = admin
-      //   .storage()
-      //   .bucket()
-      //   .file(destination);
-      // const storage = admin.storage();
-      // const pathReferenceRemix = storage.ref(destination);
-      // const config = {
-      //   action: 'read',
-      //   expires: '10-17-2025',
-      // };
-      // const urlOfRemix = await pathReferenceRemix.getSignedUrl(config);
-      // // const pathReferenceRemix = storage.ref(destination);
-      // // const urlOfRemix = await pathReferenceRemix.getDownloadURL();
-      // console.log('res url', urlOfRemix);
-      // fs.unlinkSync(data.output);
+      // TODO: see if can generate download url or signed url in cloud function
+      // instead of on the client
+
+      // delete remixed file from cloud function to clean up
+      fs.unlinkSync(data.output);
       // return resolve(urlOfRemix);
       return resolve(destination);
     })

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "css-color-names": "^1.0.1",
     "cuid": "^2.1.6",
     "docx": "^5.3.0",
-    "downloadjs": "^1.4.7",
     "edl_composer": "^1.0.3",
     "express": "^4.17.1",
     "firebase": "^7.14.0",

--- a/src/ApiWrapper/ApiWrapper.js
+++ b/src/ApiWrapper/ApiWrapper.js
@@ -998,29 +998,27 @@ class ApiWrapper {
   }
 
   // TODO: may or may not support this for web app?
-  async exportVideo({ sequence, fileName, projectId }) {
+  async exportAudioVideo({ sequence, fileName, waveForm, waveFormMode, waveFormColor, projectId }) {
     console.log('exportVideo', sequence, fileName);
     return new Promise(async (resolve, reject) => {
-      const ffmpegRemixVideo = firebase.functions().httpsCallable('ffmpegRemixVideo');
-      await ffmpegRemixVideo({
+      const ffmpegRemix = firebase.functions().httpsCallable('ffmpegRemix');
+      await ffmpegRemix({
         input: sequence,
+        waveForm,
+        waveFormMode,
+        waveFormColor,
         output: `${fileName}`,
         projectId,
       })
         .then(async ({ data }) => {
-          // Read result of the Cloud Function.
-          // var sanitizedMessage = result.data.text;
+          // Read result of the Cloud Function. it's wrapped in data attribute.
           alert('finished exporting');
           console.log('data', data);
-
           const pathReferenceRemix = storage.ref(data);
           // https://firebase.google.com/docs/storage/web/download-files#full_example
           const urlOfRemix = await pathReferenceRemix.getDownloadURL();
           console.log('res url', urlOfRemix);
           downloadURI(urlOfRemix, fileName);
-          // downloadjs(urlOfRemix, fileName, 'video/mp4');
-          // window.open(urlOfRemix, '_blank', 'noopener');
-          // TODO: prompt download from url,how?
           resolve(data);
         })
         .catch(error => {
@@ -1030,27 +1028,27 @@ class ApiWrapper {
   }
 
   // TODO: may or may not support this for web app?
-  async exportAudio({ sequence, fileName, waveForm, waveFormMode, waveFormColor, projectId }) {
-    const ffmpegRemixAudio = firebase.functions().httpsCallable('ffmpegRemixVideo');
-    return new Promise((resolve, reject) => {
-      ffmpegRemixAudio({
-        input: sequence,
-        waveForm,
-        waveFormMode,
-        waveFormColor,
-        output: `${fileName}`,
-        projectId,
-      })
-        .then(ffmpegRemixData => {
-          // Read result of the Cloud Function.
-          // var sanitizedMessage = result.data.text;
-          resolve(ffmpegRemixData);
-        })
-        .catch(error => {
-          reject(error);
-        });
-    });
-  }
+  // async exportAudio({ sequence, fileName, waveForm, waveFormMode, waveFormColor, projectId }) {
+  //   const ffmpegRemixAudio = firebase.functions().httpsCallable('ffmpegRemixVideo');
+  //   return new Promise((resolve, reject) => {
+  //     ffmpegRemixAudio({
+  //       input: sequence,
+  //       waveForm,
+  //       waveFormMode,
+  //       waveFormColor,
+  //       output: `${fileName}`,
+  //       projectId,
+  //     })
+  //       .then(ffmpegRemixData => {
+  //         // Read result of the Cloud Function.
+  //         // var sanitizedMessage = result.data.text;
+  //         resolve(ffmpegRemixData);
+  //       })
+  //       .catch(error => {
+  //         reject(error);
+  //       });
+  //   });
+  // }
 }
 
 function downloadURI(uri, name) {

--- a/src/Components/PaperEdits/PaperEdit/ProgramScript/index.js
+++ b/src/Components/PaperEdits/PaperEdit/ProgramScript/index.js
@@ -828,7 +828,14 @@ class ProgramScript extends Component {
       .replace(/:/g, '.')
       .replace(/ /g, '');
     const fileName = `${programmeScriptTitle}_${timeNow}.mp4`;
-    ApiWrapper.exportVideo({ sequence, fileName, projectId: this.props.projectId }).then(res => {
+    ApiWrapper.exportAudioVideo({
+      sequence,
+      fileName,
+      projectId: this.props.projectId,
+      waveForm: false,
+      waveFormMode: false,
+      waveFormColor: false,
+    }).then(res => {
       console.log('exported', res);
     });
   };
@@ -844,7 +851,14 @@ class ProgramScript extends Component {
       .replace(/:/g, '.')
       .replace(/ /g, '');
     const fileName = `${programmeScriptTitle}_${timeNow}.wav`;
-    ApiWrapper.exportAudio({ sequence, fileName, waveForm: false }).then(res => {
+    ApiWrapper.exportAudioVideo({
+      sequence,
+      fileName,
+      waveForm: false,
+      waveFormMode: false,
+      waveFormColor: false,
+      projectId: this.props.projectId,
+    }).then(res => {
       console.log('exported', res);
     });
   };
@@ -862,7 +876,7 @@ class ProgramScript extends Component {
     const fileName = `${programmeScriptTitle}_${timeNow}.mp4`;
     const waveForm = true;
     // const waveFormMode = 'cline';
-    ApiWrapper.exportAudio({ sequence, fileName, waveForm, waveFormMode, waveFormColor, projectId: this.props.projectId }).then(res => {
+    ApiWrapper.exportAudioVideo({ sequence, fileName, waveForm, waveFormMode, waveFormColor, projectId: this.props.projectId }).then(res => {
       console.log('exported', res);
     });
   };

--- a/src/Components/PaperEdits/PaperEdit/ProgramScript/index.js
+++ b/src/Components/PaperEdits/PaperEdit/ProgramScript/index.js
@@ -1092,33 +1092,29 @@ class ProgramScript extends Component {
                         }
                       />
 
-                      {whichJsEnv() === 'electron' ? (
-                        <>
-                          <ExportMenuItem
-                            tootlipDelay={TOOLTIP_DEPLAY_IN_MILLISECONDS}
-                            onClick={this.handleExportAudioPreview}
-                            title="Export wav audio preview - Experimental feature, at the moment you cannot combine audio and video in the same export."
-                            text={
-                              <>
-                                <FontAwesomeIcon icon={faFileAudio} /> Audio (wav) <FontAwesomeIcon icon={faFlask} />
-                                <FontAwesomeIcon icon={faInfoCircle} />
-                              </>
-                            }
-                          />
-                          <Dropdown.Divider />
-                          <ExportWaveForm
-                            TOOLTIP_DEPLAY_IN_MILLISECONDS={TOOLTIP_DEPLAY_IN_MILLISECONDS}
-                            handleExportAudioPreviewWithVideoWaveform={this.handleExportAudioPreviewWithVideoWaveform}
-                            title="Export audio preview as video with animated wave form - Experimental feature, at the moment you cannot combine audio and video in the same export."
-                            text={
-                              <>
-                                <FontAwesomeIcon icon={faFileAudio} /> Animated Waveform (mp4) <FontAwesomeIcon icon={faFlask} />
-                                <FontAwesomeIcon icon={faInfoCircle} />
-                              </>
-                            }
-                          />
-                        </>
-                      ) : null}
+                      <ExportMenuItem
+                        tootlipDelay={TOOLTIP_DEPLAY_IN_MILLISECONDS}
+                        onClick={this.handleExportAudioPreview}
+                        title="Export wav audio preview - Experimental feature, at the moment you cannot combine audio and video in the same export."
+                        text={
+                          <>
+                            <FontAwesomeIcon icon={faFileAudio} /> Audio (wav) <FontAwesomeIcon icon={faFlask} />
+                            <FontAwesomeIcon icon={faInfoCircle} />
+                          </>
+                        }
+                      />
+                      <Dropdown.Divider />
+                      <ExportWaveForm
+                        TOOLTIP_DEPLAY_IN_MILLISECONDS={TOOLTIP_DEPLAY_IN_MILLISECONDS}
+                        handleExportAudioPreviewWithVideoWaveform={this.handleExportAudioPreviewWithVideoWaveform}
+                        title="Export audio preview as video with animated wave form - Experimental feature, at the moment you cannot combine audio and video in the same export."
+                        text={
+                          <>
+                            <FontAwesomeIcon icon={faFileAudio} /> Animated Waveform (mp4) <FontAwesomeIcon icon={faFlask} />
+                            <FontAwesomeIcon icon={faInfoCircle} />
+                          </>
+                        }
+                      />
 
                       <Dropdown.Divider />
                       <ExportMenuItem


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/pietrop/digital-paper-edit-firebase/issues) in this repository ?**
<!-- _If so please link to other issues and PRs as appropriate_ -->
[card](https://github.com/pietrop/digital-paper-edit-firebase/projects/2#card-48816991) in [project board](https://github.com/pietrop/digital-paper-edit-firebase/projects/2)

**Describe what the PR does**
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->

Adds support for `ffmpeg-remix` to export audio, and audio wave form of paper-edit. 
For now still just uses cloud function that will time out after 9 min. 
Refactor to App engine is for subsequent PR. 
This PR mostly focuses on wiring client, with backend to add that option. 

**State whether the PR is ready for review or whether it needs extra work**
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Work in prrogress
**Additional context**
<!-- Add any other context or screenshots about the PR. -->
_NA_