### PR TITLE
added collections for words and paragraphs

### DIFF
--- a/functions/createTranscript/index.js
+++ b/functions/createTranscript/index.js
@@ -109,10 +109,35 @@ exports.createHandler = async (change, context, admin, AUDIO_EXTENSION, SAMPLE_R
     //  const [response] = await operation.promise();
     const transcript = gcpToDpe(initialApiResponse);
     const { paragraphs, words } = transcript;
+
+    change.ref
+      .collection('words')
+      .doc('words')
+      .set(
+        {
+          words,
+        },
+        {
+          merge: true,
+        }
+      );
+
+    change.ref
+      .collection('paragraphs')
+      .doc('paragraphs')
+      .set(
+        {
+          paragraphs,
+        },
+        {
+          merge: true,
+        }
+      );
+
     return change.ref.set(
       {
-        paragraphs,
-        words,
+        // paragraphs,
+        // words,
         status: 'done',
         sttEngine: 'GoogleCloud',
       },

--- a/functions/ffmpeg-remix/index.js
+++ b/functions/ffmpeg-remix/index.js
@@ -90,7 +90,7 @@ const concat = (data, tmpDir, callback) => {
     ff.on('end', () => {
       console.log(`Created: ${data.output}`);
       // Clean up and delete temp files .ts
-      rimraf(`${tmpDir}/*.ts`, function() {
+      rimraf(`${tmpDir}/*.ts`, () => {
         console.log('delete .ts files');
       });
       callback(null, data);

--- a/functions/firestoreCheckSTT/index.js
+++ b/functions/firestoreCheckSTT/index.js
@@ -35,20 +35,44 @@ exports.createHandler = async (req, res, admin, functions) => {
           console.log('transcript words');
           console.log('docPath', docPath);
 
-          await admin
-            .firestore()
-            .doc(docPath)
+          const transcriptRef = admin.firestore().doc(docPath);
+
+          await transcriptRef
+            .collection('words')
+            .doc('words')
             .set(
               {
-                paragraphs,
                 words,
-                status: 'done',
-                sttEngine: 'GoogleCloud',
               },
               {
                 merge: true,
               }
             );
+
+          await transcriptRef
+            .collection('paragraphs')
+            .doc('paragraphs')
+            .set(
+              {
+                paragraphs,
+              },
+              {
+                merge: true,
+              }
+            );
+
+          await transcriptRef.set(
+            {
+              // paragraphs,
+              // words,
+              status: 'done',
+              sttEngine: 'GoogleCloud',
+            },
+            {
+              merge: true,
+            }
+          );
+
           console.log('admin write');
           return res.sendStatus(200);
         } else {

--- a/src/Util/words-tsv-serializer/index.js
+++ b/src/Util/words-tsv-serializer/index.js
@@ -1,0 +1,60 @@
+/**
+ * Helper functions to serialize and de-serialize array of words into a tsv string
+  example words list
+  ```
+  [
+    {
+      "id": 0,
+      "start": 1.4,
+      "end": 3.9,
+      "text": "Can"
+    },
+    {
+      "id": 1,
+      "start": 3.9,
+      "end": 4,
+      "text": "you"
+    },
+    {
+      "id": 2,
+      "start": 4,
+      "end": 4.1,
+      "text": "hear"
+    },
+    {
+      "id": 3,
+      "start": 4.1,
+      "end": 4.2,
+      "text": "it?"
+    },
+    ..
+]
+```
+example converted tsv string
+```
+1.4\t	3.9\t	Can\n
+3.9\t	4\t	you\n
+4\t	4.1\t	hear\n
+4.1\t	4.2\t	it?\n
+```
+ */
+function serializeWordsToTsv(words) {
+  return words
+    .map(word => {
+      return `${word.start}\t${word.end}\t${word.text}`;
+    })
+    .join('\n');
+}
+
+function deserializeTsvToWords(data) {
+  return data.split('\n').map(w => {
+    const warray = w.split('\t');
+    return {
+      start: warray[0],
+      end: warray[1],
+      text: warray[2],
+    };
+  });
+}
+
+export { serializeWordsToTsv, deserializeTsvToWords };


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/pietrop/digital-paper-edit-firebase/issues) in this repository ?**
<!-- _If so please link to other issues and PRs as appropriate_ -->
_NA_
**Describe what the PR does**
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->

as described in [card](https://github.com/pietrop/digital-paper-edit-firebase/projects/2#card-48137765)

> [DEV]:  {words and paragraphs part 1/2} Consider moving words and paragraphs as subcollections
> - [x] when getting a list of transcripts, this makes the payload smaller. coz we only need title and description at that point
> -  [x] APIWrapper createTranscript, remove [] for words and paragraphs. 
> - [x] Cloud functions (x2) to create transcripts, create collection for words and paragraphs
> - [x] need to add delete of those two sub collection when deleting a transcript and/or a project.
> - [x] change update transcript to collections

**State whether the PR is ready for review or whether it needs extra work**
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->

Ready

**Additional context**
<!-- Add any other context or screenshots about the PR. -->
When getting list of transcripts, eg for a project, the payload can be smaller, as we just need title, description, etc.. as we don't need the transcript paragraphs and words until we call the individual one.
